### PR TITLE
Supply typescript definitions

### DIFF
--- a/lib/Pushy.d.ts
+++ b/lib/Pushy.d.ts
@@ -1,0 +1,35 @@
+import {BrowserWindow} from "electron";
+
+declare namespace Pushy {
+
+    type DeviceToken = string
+
+    type Listener<T> = (data: T) => void
+
+    function listen(): void
+
+    function setNotificationListener<T>(l: Listener<T>): void
+
+    function register(opts: { appId: string }): Promise<DeviceToken>
+
+    function isRegistered(): boolean
+
+    function subscribe(topics: string | string[]): Promise<void>
+
+    function unsubscribe(topics: string | string[]): Promise<void>
+
+    function validateDeviceCredentials(): Promise<void>
+
+    function setHeartbeatInterval(seconds: number): void
+
+    function isEnterpriseConfigured(): boolean
+
+    function setEnterpriseConfig(endpoint: string, mqttEndpoint: string): void
+
+    function disconnect(): void
+
+    function alert(win: BrowserWindow, msg: string)
+}
+
+export = Pushy
+export as namespace Pushy

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "author": "Pushy <support@pushy.me>",
   "license": "Apache-2.0",
   "main": "lib/Pushy.js",
+  "typings": "lib/Pushy.d.ts",
   "//": "Also update version in config.js",
   "version": "1.0.6",
   "scripts": {


### PR DESCRIPTION
This makes the library usable out of the box in a typescript project.
Without these definitions, users need to handcraft their own definitions, at least this: 

```ts
type DeviceToken = string

type Listener<T> = (data: T) => void

declare module "pushy-electron" {
    export function listen(): void
    export function register(opts: { appId: string }): Promise<DeviceToken>
    export function setNotificationListener<T>(listener: Listener<T>): void
}
```