### PR TITLE
Add missing return type annotation

### DIFF
--- a/lib/Pushy.d.ts
+++ b/lib/Pushy.d.ts
@@ -28,7 +28,7 @@ declare namespace Pushy {
 
     function disconnect(): void
 
-    function alert(win: BrowserWindow, msg: string)
+    function alert(win: BrowserWindow, msg: string): void
 }
 
 export = Pushy


### PR DESCRIPTION
My apologies for missing this one out. This fixes:

`TS7010: 'alert', which lacks return-type annotation, implicitly has an 'any' return type.`